### PR TITLE
Update TabContainer to use max-w-4xl (90%)

### DIFF
--- a/src/components/KlientoHomepage/TabContainer/CodeBlock.tsx
+++ b/src/components/KlientoHomepage/TabContainer/CodeBlock.tsx
@@ -61,23 +61,20 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
         </button>
       )}
 
-      <div className="overflow-x-auto">
-        <SyntaxHighlighter
-          language={language.toLowerCase()}
-          style={vscDarkPlus}
-          customStyle={{
-            margin: 0,
-            padding: 0,
-            background: "transparent",
-            fontSize: fontSize,
-            lineHeight: "1.5",
-            maxWidth: "100%",
-          }}
-          codeTagProps={{ style: { fontSize: "inherit" } }}
-        >
-          {code}
-        </SyntaxHighlighter>
-      </div>
+      <SyntaxHighlighter
+        language={language.toLowerCase()}
+        style={vscDarkPlus}
+        customStyle={{
+          margin: 0,
+          padding: 0,
+          background: "transparent",
+          fontSize: fontSize,
+          lineHeight: "1.5",
+        }}
+        codeTagProps={{ style: { fontSize: "inherit" } }}
+      >
+        {code}
+      </SyntaxHighlighter>
     </div>
   );
 };

--- a/src/components/KlientoHomepage/TabContainer/TabContainer.tsx
+++ b/src/components/KlientoHomepage/TabContainer/TabContainer.tsx
@@ -33,7 +33,7 @@ const TabContainer: React.FC<TabContainerProps> = ({ tabs, className = "" }) => 
 
   return (
     <div
-      className={`rounded-md lg:max-w-[80%] w-full mx-auto bg-gradient-to-r from-indigo-500 from-10% via-indigo-400 via-30% to-emerald-500 to-90% p-[2px] ${className}`}
+      className={`rounded-md max-w-4xl mx-auto bg-gradient-to-r from-indigo-500 from-10% via-indigo-400 via-30% to-emerald-500 to-90% p-[2px] ${className}`}
     >
       <div className="rounded-md overflow-hidden bg-black h-full">
         <div className="flex overflow-x-auto whitespace-nowrap flex-nowrap border-b border-neutral-800">


### PR DESCRIPTION
Also, remove unnecessary div wrapper around SyntaxHighlighter in CodeBlock for cleaner structure.
