### PR TITLE
Tweak kliento homepage

### DIFF
--- a/src/components/KlientoHomepage/Hero.astro
+++ b/src/components/KlientoHomepage/Hero.astro
@@ -13,13 +13,12 @@ import { AnimatedSection } from "../AnimatedSection";
         class="w-full h-full object-cover opacity-80"
       />
     </div>
+
     <div class="relative px-4 sm:px-6 space-y-4 lg:space-y-8">
-      <h1 class="text-[2.5rem] sm:text-5xl md:text-6xl lg:text-[5.5rem] text-center leading-tight">
-        <span
-          class="bg-gradient-to-r from-indigo-600 via-indigo-400 to-indigo-200 text-transparent bg-clip-text"
-          >Workload authentication</span
-        >
-        <br />simplified
+      <h1
+        class="text-[2.5rem] sm:text-5xl md:text-6xl lg:text-[5.5rem] text-center leading-tight bg-gradient-to-r from-[#839cff] via-[#a3b6ff] to-[#e4efff] !text-transparent bg-clip-text"
+      >
+        Workload authentication simplified
       </h1>
       <p class="text-center text-base md:text-xl lg:text-2xl">
         Without secrets to protect or public keys to distribute

--- a/src/components/KlientoHomepage/Hero.astro
+++ b/src/components/KlientoHomepage/Hero.astro
@@ -4,7 +4,7 @@ import dottedPattern from "../../assets/images/dotted-pattern.svg";
 import { AnimatedSection } from "../AnimatedSection";
 ---
 
-<section class="relative py-8 sm:py-16 bg-black">
+<section class="relative py-8 sm:pt-11 sm:pb-16 bg-black">
   <div class="max-w-7xl mx-auto">
     <div class="absolute inset-0 w-full h-full">
       <Image
@@ -16,7 +16,7 @@ import { AnimatedSection } from "../AnimatedSection";
 
     <div class="relative px-4 sm:px-6 space-y-4 lg:space-y-8">
       <h1
-        class="text-[2.5rem] sm:text-5xl md:text-6xl lg:text-[5.5rem] text-center leading-tight bg-gradient-to-r from-[#839cff] via-[#a3b6ff] to-[#e4efff] !text-transparent bg-clip-text"
+        class="text-[2.5rem] sm:text-5xl md:text-6xl lg:text-[5.5rem] text-center leading-tight bg-gradient-to-r from-indigo-400 via-indigo-300 to-indigo-200 !text-transparent bg-clip-text"
       >
         Workload authentication simplified
       </h1>

--- a/src/components/KlientoHomepage/ServicesAccount.astro
+++ b/src/components/KlientoHomepage/ServicesAccount.astro
@@ -8,7 +8,7 @@ import VeraidIdentifier from "./VeraidIdentifier.astro";
       <div class="order-1">
         <h2 class="text-3xl sm:text-4xl md:text-5xl lg:text-[3.5rem] leading-tight">
           Kliento brings <span
-            class="bg-gradient-to-r from-[#718dff] via-[#a3b6ff] to-[#c2dbff] !text-transparent bg-clip-text"
+            class="bg-gradient-to-r from-indigo-400 via-indigo-300 to-indigo-200 !text-transparent bg-clip-text"
             >service accounts</span
           > to the Internet
         </h2>

--- a/src/components/KlientoHomepage/ServicesAccount.astro
+++ b/src/components/KlientoHomepage/ServicesAccount.astro
@@ -8,7 +8,7 @@ import VeraidIdentifier from "./VeraidIdentifier.astro";
       <div class="order-1">
         <h2 class="text-3xl sm:text-4xl md:text-5xl lg:text-[3.5rem] leading-tight">
           Kliento brings <span
-            class="bg-gradient-to-r from-indigo-600 via-indigo-400 to-indigo-200 text-transparent bg-clip-text"
+            class="bg-gradient-to-r from-[#718dff] via-[#a3b6ff] to-[#c2dbff] !text-transparent bg-clip-text"
             >service accounts</span
           > to the Internet
         </h2>

--- a/src/components/KlientoHomepage/TabContainer/CodeBlock.tsx
+++ b/src/components/KlientoHomepage/TabContainer/CodeBlock.tsx
@@ -20,7 +20,13 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
 
   useEffect(() => {
     const handleResize = () => {
-      setFontSize(window.innerWidth < 640 ? "0.75rem" : "1rem");
+      if (window.innerWidth < 640) {
+        setFontSize("0.75rem");
+      } else if (window.innerWidth < 1024) {
+        setFontSize("0.875rem");
+      } else {
+        setFontSize("1rem");
+      }
     };
 
     handleResize();

--- a/src/components/KlientoHomepage/TabContainer/TabContainerClientIntegration.tsx
+++ b/src/components/KlientoHomepage/TabContainer/TabContainerClientIntegration.tsx
@@ -5,7 +5,7 @@ import CodeBlock from "./CodeBlock";
 import JavaScriptIcon from "../../../assets/icons/JavaScript.svg?react";
 import GitHubIcon from "../../../assets/icons/github.svg?react";
 
-const PARAGRAPH = "px-4 text-xs lg:text-base leading-normal pb-4";
+const PARAGRAPH = "px-4 text-xs sm:text-sm lg:text-base leading-normal pb-4";
 const CONTENT_CONTAINER = "text-left pt-4 bg-black";
 
 const TabContainerClientIntegration: React.FC = () => {

--- a/src/components/KlientoHomepage/TabContainer/TabContainerServerVerification.tsx
+++ b/src/components/KlientoHomepage/TabContainer/TabContainerServerVerification.tsx
@@ -4,7 +4,7 @@ import type { Tab } from "./TabContainer";
 import CodeBlock from "./CodeBlock";
 import JavaScriptIcon from "../../../assets/icons/JavaScript.svg?react";
 
-const PARAGRAPH = "px-4 text-xs lg:text-base leading-normal pb-4";
+const PARAGRAPH = "px-4 text-xs sm:text-sm lg:text-base leading-normal pb-4";
 const CONTENT_CONTAINER = "text-left pt-4 bg-black";
 
 const TabContainerServerVerification: React.FC = () => {

--- a/src/components/KlientoHomepage/TokenBundle.astro
+++ b/src/components/KlientoHomepage/TokenBundle.astro
@@ -15,7 +15,7 @@ import CtaButton from "../CtaButton.astro";
       <div class="text-left order-1 lg:order-2 space-y-6 text-sm lg:text-base">
         <h2 class="text-3xl sm:text-4xl md:text-5xl lg:text-[3.5rem]">
           Kliento credentials are <span
-            class="bg-gradient-to-r from-indigo-600 via-indigo-400 to-indigo-200 text-transparent bg-clip-text"
+            class="bg-gradient-to-r from-[#839cff] via-[#a3b6ff] to-[#e4efff] !text-transparent bg-clip-text"
             >self-contained</span
           >
         </h2>

--- a/src/components/KlientoHomepage/TokenBundle.astro
+++ b/src/components/KlientoHomepage/TokenBundle.astro
@@ -15,7 +15,7 @@ import CtaButton from "../CtaButton.astro";
       <div class="text-left order-1 lg:order-2 space-y-6 text-sm lg:text-base">
         <h2 class="text-3xl sm:text-4xl md:text-5xl lg:text-[3.5rem]">
           Kliento credentials are <span
-            class="bg-gradient-to-r from-[#839cff] via-[#a3b6ff] to-[#e4efff] !text-transparent bg-clip-text"
+            class="bg-gradient-to-r from-indigo-400 via-indigo-300 to-indigo-200 !text-transparent bg-clip-text"
             >self-contained</span
           >
         </h2>

--- a/src/components/KlientoHomepage/VeraidIdentifier.astro
+++ b/src/components/KlientoHomepage/VeraidIdentifier.astro
@@ -9,12 +9,12 @@ const identifiers = [
 ---
 
 <div
-  class="w-full h-[64px] overflow-hidden border-2 rounded-md border-neutral-700 bg-neutral-800 text-lg relative carousel-container"
+  class="w-full h-[64px] overflow-hidden rounded-md border-2 border-neutral-700 bg-neutral-800 text-lg relative carousel-container"
 >
   <div class="absolute top-0 left-0 w-full text-wrapper text-white">
     {
       identifiers.map((identifier) => (
-        <div class="h-[64px] flex items-center justify-center px-4">{identifier}</div>
+        <div class="h-[60px] flex items-center justify-center px-4">{identifier}</div>
       ))
     }
   </div>
@@ -34,31 +34,31 @@ const identifiers = [
     }
 
     20% {
-      transform: translateY(-64px);
+      transform: translateY(-60px);
     }
     35% {
-      transform: translateY(-64px);
+      transform: translateY(-60px);
     }
 
     40% {
-      transform: translateY(-128px);
+      transform: translateY(-120px);
     }
     55% {
-      transform: translateY(-128px);
+      transform: translateY(-120px);
     }
 
     60% {
-      transform: translateY(-192px);
+      transform: translateY(-180px);
     }
     75% {
-      transform: translateY(-192px);
+      transform: translateY(-180px);
     }
 
     80% {
-      transform: translateY(-256px);
+      transform: translateY(-240px);
     }
     95% {
-      transform: translateY(-256px);
+      transform: translateY(-240px);
     }
 
     100% {

--- a/src/layouts/KlientoPage.astro
+++ b/src/layouts/KlientoPage.astro
@@ -11,5 +11,19 @@ import klientoLogo from "../assets/images/kliento-logo.png";
     logoSrc={klientoLogo.src}
     slot="kliento-header"
   />
-  <slot />
+  <div class="kliento-content">
+    <slot />
+  </div>
 </Page>
+<style>
+  /* Override link styles for Kliento pages */
+  :global(.kliento-content a) {
+    color: #839cff !important;
+    text-decoration: none;
+  }
+
+  :global(.kliento-content a:hover) {
+    color: #a3b6ff !important;
+    text-decoration: underline;
+  }
+</style>

--- a/src/layouts/KlientoPage.astro
+++ b/src/layouts/KlientoPage.astro
@@ -2,6 +2,7 @@
 import { SecondaryNav } from "../components/TopNav/SecondaryNav";
 import Page from "./Page.astro";
 import klientoLogo from "../assets/images/kliento-logo.png";
+import "../styles/kliento.css";
 ---
 
 <Page {...Astro.props} showBrandInTitle={false}>

--- a/src/layouts/KlientoPage.astro
+++ b/src/layouts/KlientoPage.astro
@@ -15,15 +15,3 @@ import klientoLogo from "../assets/images/kliento-logo.png";
     <slot />
   </div>
 </Page>
-<style>
-  /* Override link styles for Kliento pages */
-  :global(.kliento-content a) {
-    color: #839cff !important;
-    text-decoration: none;
-  }
-
-  :global(.kliento-content a:hover) {
-    color: #a3b6ff !important;
-    text-decoration: underline;
-  }
-</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,3 +11,11 @@ html {
 :not(pre) > code {
   @apply bg-neutral-700 rounded-sm py-0.5 px-1 border border-neutral-600;
 }
+
+.kliento-content a {
+  @apply text-indigo-300;
+}
+
+.kliento-content a:hover {
+  @apply text-indigo-400;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,11 +11,3 @@ html {
 :not(pre) > code {
   @apply bg-neutral-700 rounded-sm py-0.5 px-1 border border-neutral-600;
 }
-
-.kliento-content a {
-  @apply text-indigo-300;
-}
-
-.kliento-content a:hover {
-  @apply text-indigo-400;
-}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,29 +11,3 @@ html {
 :not(pre) > code {
   @apply bg-neutral-700 rounded-sm py-0.5 px-1 border border-neutral-600;
 }
-
-/* Scrollbar Styling */
-/* For WebKit browsers (Chrome, Safari, Edge) */
-::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
-
-::-webkit-scrollbar-track {
-  background: #1a1a1a; /* Dark background color */
-}
-
-::-webkit-scrollbar-thumb {
-  background: #555; /* Thumb color */
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #777;
-}
-
-/* For Firefox */
-* {
-  scrollbar-color: #5b5b5b #2c2c2c; /* thumb color track color */
-  scrollbar-width: thin;
-}

--- a/src/styles/kliento.css
+++ b/src/styles/kliento.css
@@ -1,0 +1,25 @@
+@import "tailwindcss";
+
+.kliento-content a {
+  @apply text-indigo-300;
+}
+
+.kliento-content a:hover {
+  @apply text-indigo-400;
+}
+
+.kliento-content code > a {
+  @apply text-indigo-300;
+}
+
+.kliento-content code > a:hover {
+  @apply text-indigo-400;
+}
+
+.kliento-content a > code {
+  @apply text-indigo-300;
+}
+
+.kliento-content a > code:hover {
+  @apply text-indigo-400;
+}


### PR DESCRIPTION
VMKTG-32

- [x] Header title: Use a single gradient.
- [x] Text gradient: Start from lighter colour.
- [x] Service account input field: Vertically centre text.
- [x] Remove global CSS for the scrolling bar
- [x] Add link style for all kliento related markdown pages
- [x] Add font size for small viewport for the code snippets

